### PR TITLE
feat: Add public API for email subscriptions

### DIFF
--- a/src/controllers/subscription.controller.js
+++ b/src/controllers/subscription.controller.js
@@ -1,0 +1,27 @@
+const { Subscription } = require('../models');
+
+const createSubscription = async (req, res) => {
+  const { email } = req.body;
+
+  if (!email) {
+    return res.status(400).json({ message: 'Email is required.' });
+  }
+
+  try {
+    const subscription = await Subscription.create({ email });
+    res.status(201).json({ message: 'Subscription successful.', subscription });
+  } catch (error) {
+    if (error.name === 'SequelizeUniqueConstraintError') {
+      return res.status(409).json({ message: 'This email is already subscribed.' });
+    }
+    if (error.name === 'SequelizeValidationError') {
+      return res.status(400).json({ message: 'Invalid email format.' });
+    }
+    console.error(error);
+    res.status(500).json({ message: 'Something went wrong while subscribing.', error: error.message });
+  }
+};
+
+module.exports = {
+  createSubscription,
+};

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -55,6 +55,7 @@ User.hasMany(Donation, { foreignKey: 'userId', as: 'donations' });
 Donation.belongsTo(User, { foreignKey: 'userId', as: 'user' });
 
 const ENewspaper = require('./enewspaper.model')(sequelize);
+const Subscription = require('./subscription.model')(sequelize);
 
 User.hasMany(ENewspaper, { foreignKey: 'userId', as: 'enewspapers' });
 ENewspaper.belongsTo(User, { foreignKey: 'userId', as: 'user' });
@@ -67,5 +68,6 @@ module.exports = {
   Gallery,
   Donation,
   ENewspaper,
+  Subscription,
 };
 

--- a/src/models/subscription.model.js
+++ b/src/models/subscription.model.js
@@ -1,0 +1,29 @@
+const { Model, DataTypes } = require('sequelize');
+
+module.exports = (sequelize) => {
+  class Subscription extends Model {}
+
+  Subscription.init({
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+      allowNull: false,
+    },
+    email: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true,
+      validate: {
+        isEmail: true,
+      },
+    },
+  }, {
+    sequelize,
+    modelName: 'Subscription',
+    tableName: 'subscriptions',
+    timestamps: true,
+  });
+
+  return Subscription;
+};

--- a/src/routes/subscription.routes.js
+++ b/src/routes/subscription.routes.js
@@ -1,0 +1,42 @@
+const express = require('express');
+const { createSubscription } = require('../controllers/subscription.controller');
+
+const router = express.Router();
+
+/**
+ * @swagger
+ * tags:
+ *   name: Subscription
+ *   description: Subscription management
+ */
+
+/**
+ * @swagger
+ * /api/subscribe:
+ *   post:
+ *     summary: Subscribe to the newsletter
+ *     tags: [Subscription]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - email
+ *             properties:
+ *               email:
+ *                 type: string
+ *                 format: email
+ *                 description: The email address to subscribe.
+ *     responses:
+ *       '201':
+ *         description: Subscription successful
+ *       '400':
+ *         description: Bad request (e.g., missing email, invalid format)
+ *       '409':
+ *         description: This email is already subscribed
+ */
+router.post('/', createSubscription);
+
+module.exports = router;

--- a/src/server.js
+++ b/src/server.js
@@ -22,6 +22,7 @@ const adminRoutes = require("./routes/admin.routes");
 const newsRoutes = require("./routes/news.routes");
 const enewspaperRoutes = require("./routes/enewspaper.routes");
 const ngoRoutes = require("./routes/ngo.routes");
+const subscriptionRoutes = require("./routes/subscription.routes");
 const { sequelize } = require("./models");
 
 app.get("/", (req, res) => {
@@ -37,6 +38,7 @@ app.use("/api/admin", adminRoutes);
 app.use("/api/news", newsRoutes);
 app.use("/api/enewspapers", enewspaperRoutes);
 app.use("/api/ngo", ngoRoutes);
+app.use("/api/subscribe", subscriptionRoutes);
 
 const PORT = process.env.PORT || 3000;
 

--- a/tests/subscription.test.js
+++ b/tests/subscription.test.js
@@ -1,0 +1,68 @@
+// Mock the sequelize config to use SQLite for tests.
+jest.mock('../src/config/sequelize.js', () => {
+  const { Sequelize } = require('sequelize');
+  return new Sequelize('sqlite::memory:', { logging: false });
+});
+
+const request = require('supertest');
+const { app } = require('../src/server');
+const { Subscription, sequelize } = require('../src/models');
+
+describe('Subscription API', () => {
+  let server;
+
+  beforeAll(async () => {
+    await sequelize.sync({ force: true });
+    server = app.listen(4012); // Use a unique port for this test suite
+  });
+
+  afterEach(async () => {
+    // Clear the subscriptions table after each test
+    await Subscription.destroy({ where: {} });
+  });
+
+  afterAll(async () => {
+    // Close the database connection and the server
+    await sequelize.close();
+    server.close();
+  });
+
+  describe('POST /api/subscribe', () => {
+    it('should subscribe a user with a valid email', async () => {
+      const res = await request(app)
+        .post('/api/subscribe')
+        .send({ email: 'test@example.com' });
+      expect(res.statusCode).toEqual(201);
+      expect(res.body.message).toBe('Subscription successful.');
+      expect(res.body.subscription.email).toBe('test@example.com');
+    });
+
+    it('should not subscribe a user with an invalid email', async () => {
+      const res = await request(app)
+        .post('/api/subscribe')
+        .send({ email: 'not-an-email' });
+      expect(res.statusCode).toEqual(400);
+      expect(res.body.message).toBe('Invalid email format.');
+    });
+
+    it('should not subscribe a user with an existing email', async () => {
+      // First, create a subscription
+      await Subscription.create({ email: 'test@example.com' });
+
+      // Then, try to subscribe with the same email
+      const res = await request(app)
+        .post('/api/subscribe')
+        .send({ email: 'test@example.com' });
+      expect(res.statusCode).toEqual(409);
+      expect(res.body.message).toBe('This email is already subscribed.');
+    });
+
+    it('should not subscribe a user without an email', async () => {
+        const res = await request(app)
+            .post('/api/subscribe')
+            .send({});
+        expect(res.statusCode).toEqual(400);
+        expect(res.body.message).toBe('Email is required.');
+    });
+  });
+});


### PR DESCRIPTION
This commit introduces a new feature that allows users to subscribe to a newsletter or updates by providing their email address.

The following changes are included:
- A new `Subscription` model to store subscriber emails.
- A `subscription.controller.js` to handle the business logic for creating new subscriptions.
- A new public route `/api/subscribe` defined in `subscription.routes.js`.
- Integration of the new subscription route into the main `server.js` file.
- A new test suite (`tests/subscription.test.js`) to ensure the functionality of the subscription API, including tests for successful subscription, invalid email format, and duplicate email addresses.